### PR TITLE
Refactors the healthcheck GUID generator to take a prefix

### DIFF
--- a/gardenhealth/checker.go
+++ b/gardenhealth/checker.go
@@ -129,7 +129,7 @@ func (c *checker) create(logger lager.Logger) (string, garden.Container, error) 
 	logger.Debug("starting")
 	defer logger.Debug("finished")
 
-	guid := HealthcheckPrefix + c.guidGenerator.Guid(logger)
+	guid := c.guidGenerator.Guid(logger, HealthcheckPrefix)
 	var container garden.Container
 	err := retryOnFail(c.retryInterval, func(attempt uint) (createErr error) {
 		container, createErr = c.gardenClient.Create(garden.ContainerSpec{

--- a/gardenhealth/checker_test.go
+++ b/gardenhealth/checker_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Checker", func() {
 		logger = lagertest.NewTestLogger("test")
 		gardenClient = &gardenfakes.FakeClient{}
 		guidGenerator := &fakeguidgen.FakeGenerator{}
-		guidGenerator.GuidReturns("abc-123")
+		guidGenerator.GuidReturns("executor-healthcheck-abc-123")
 		gardenChecker = gardenhealth.NewChecker(rootfsPath, containerOwnerName, 0, healthcheckSpec, gardenClient, guidGenerator)
 	})
 

--- a/guidgen/fakeguidgen/fake_generator.go
+++ b/guidgen/fakeguidgen/fake_generator.go
@@ -9,10 +9,11 @@ import (
 )
 
 type FakeGenerator struct {
-	GuidStub        func(lager.Logger) string
+	GuidStub        func(lager.Logger, string) string
 	guidMutex       sync.RWMutex
 	guidArgsForCall []struct {
 		arg1 lager.Logger
+		arg2 string
 	}
 	guidReturns struct {
 		result1 string
@@ -21,15 +22,16 @@ type FakeGenerator struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeGenerator) Guid(arg1 lager.Logger) string {
+func (fake *FakeGenerator) Guid(arg1 lager.Logger, arg2 string) string {
 	fake.guidMutex.Lock()
 	fake.guidArgsForCall = append(fake.guidArgsForCall, struct {
 		arg1 lager.Logger
-	}{arg1})
-	fake.recordInvocation("Guid", []interface{}{arg1})
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("Guid", []interface{}{arg1, arg2})
 	fake.guidMutex.Unlock()
 	if fake.GuidStub != nil {
-		return fake.GuidStub(arg1)
+		return fake.GuidStub(arg1, arg2)
 	} else {
 		return fake.guidReturns.result1
 	}
@@ -41,10 +43,10 @@ func (fake *FakeGenerator) GuidCallCount() int {
 	return len(fake.guidArgsForCall)
 }
 
-func (fake *FakeGenerator) GuidArgsForCall(i int) lager.Logger {
+func (fake *FakeGenerator) GuidArgsForCall(i int) (lager.Logger, string) {
 	fake.guidMutex.RLock()
 	defer fake.guidMutex.RUnlock()
-	return fake.guidArgsForCall[i].arg1
+	return fake.guidArgsForCall[i].arg1, fake.guidArgsForCall[i].arg2
 }
 
 func (fake *FakeGenerator) GuidReturns(result1 string) {

--- a/guidgen/generator.go
+++ b/guidgen/generator.go
@@ -10,15 +10,15 @@ var DefaultGenerator Generator = &generator{}
 //go:generate counterfeiter -o fakeguidgen/fake_generator.go . Generator
 
 type Generator interface {
-	Guid(lager.Logger) string
+	Guid(lager.Logger, string) string
 }
 
 type generator struct{}
 
-func (*generator) Guid(logger lager.Logger) string {
+func (*generator) Guid(logger lager.Logger, prefix string) string {
 	guid, err := uuid.NewV4()
 	if err != nil {
 		logger.Fatal("failed-to-generate-guid", err)
 	}
-	return guid.String()
+	return prefix + guid.String()
 }

--- a/guidgen/generator_test.go
+++ b/guidgen/generator_test.go
@@ -1,0 +1,19 @@
+package guidgen_test
+
+import (
+	. "code.cloudfoundry.org/executor/guidgen"
+	"code.cloudfoundry.org/lager/lagertest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GUID Generator", func() {
+	Context("when a prefix is provided", func() {
+		It("prepends the prefix to the guid", func() {
+			logger := lagertest.NewTestLogger("test")
+			Expect(DefaultGenerator.Guid(logger, "prefix")).To(HavePrefix("prefix"))
+			Expect(DefaultGenerator.Guid(logger, "someting")).To(HavePrefix("someting"))
+		})
+	})
+})

--- a/guidgen/guidgen_suite_test.go
+++ b/guidgen/guidgen_suite_test.go
@@ -1,0 +1,13 @@
+package guidgen_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestGuidgen(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Guidgen Suite")
+}


### PR DESCRIPTION
As discussed in issue #1, this PR implements a small refactor to the guid generator. It now takes a prefix that will be prepended to the front of the returned guid.
